### PR TITLE
Pytest warning fix for contract test contract_update_without_create

### DIFF
--- a/src/rpdk/core/contract/suite/resource/handler_update_invalid.py
+++ b/src/rpdk/core/contract/suite/resource/handler_update_invalid.py
@@ -25,4 +25,3 @@ def contract_update_without_create(resource_client):
         "message"
     ], "The progress event MUST return an error message\
          when the status is failed"
-    return _error

--- a/src/rpdk/core/contract/suite/resource/handler_update_invalid.py
+++ b/src/rpdk/core/contract/suite/resource/handler_update_invalid.py
@@ -10,18 +10,24 @@ from rpdk.core.contract.suite.contract_asserts_commons import failed_event
 
 
 @pytest.mark.update
+def contract_update_without_create(resource_client):
+    test_update_without_create(resource_client)
+
+
 @failed_event(
     error_code=HandlerErrorCode.NotFound,
     msg="An update handler MUST return FAILED with a NotFound error code\
          if the resource did not exist prior to the update request",
 )
-def contract_update_without_create(resource_client):
+def test_update_without_create(resource_client):
     create_request = resource_client.generate_create_example()
     update_request = resource_client.generate_update_example(create_request)
     _status, response, _error = resource_client.call_and_assert(
-        Action.UPDATE, OperationStatus.FAILED, update_request, create_request
+      Action.UPDATE, OperationStatus.FAILED, update_request, create_request
     )
     assert response[
-        "message"
+      "message"
     ], "The progress event MUST return an error message\
          when the status is failed"
+
+    return _error

--- a/src/rpdk/core/contract/suite/resource/handler_update_invalid.py
+++ b/src/rpdk/core/contract/suite/resource/handler_update_invalid.py
@@ -23,10 +23,10 @@ def test_update_without_create(resource_client):
     create_request = resource_client.generate_create_example()
     update_request = resource_client.generate_update_example(create_request)
     _status, response, _error = resource_client.call_and_assert(
-      Action.UPDATE, OperationStatus.FAILED, update_request, create_request
+        Action.UPDATE, OperationStatus.FAILED, update_request, create_request
     )
     assert response[
-      "message"
+        "message"
     ], "The progress event MUST return an error message\
          when the status is failed"
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix for Pytest warning
```
resource/handler_update_invalid.py::contract_update_without_create
  /opt/homebrew/lib/python3.10/site-packages/_pytest/python.py:199: PytestReturnNotNoneWarning: Expected None, but resource/handler_update_invalid.py::contract_update_without_create returned <HandlerErrorCode.NotFound: 'NotFound'>, which will be an error in a future version of pytest.  Did you mean to use `assert` instead of `return`?
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
